### PR TITLE
Animate gauges on update

### DIFF
--- a/dist/LinearGauge.js
+++ b/dist/LinearGauge.js
@@ -40,6 +40,7 @@ var ReactLinearGauge = function (_React$Component) {
   }, {
     key: 'componentWillReceiveProps',
     value: function componentWillReceiveProps(nextProps) {
+      this.gauge.value = nextProps.value;
       this.gauge.update(nextProps);
     }
   }, {

--- a/dist/RadialGauge.js
+++ b/dist/RadialGauge.js
@@ -40,6 +40,7 @@ var ReactRadialGauge = function (_React$Component) {
   }, {
     key: 'componentWillReceiveProps',
     value: function componentWillReceiveProps(nextProps) {
+      this.gauge.value = nextProps.value;
       this.gauge.update(nextProps);
     }
   }, {

--- a/src/LinearGauge.jsx
+++ b/src/LinearGauge.jsx
@@ -11,6 +11,7 @@ class ReactLinearGauge extends React.Component {
   }
 
   componentWillReceiveProps (nextProps) {
+    this.gauge.value = nextProps.value
     this.gauge.update(nextProps)
   }
 

--- a/src/RadialGauge.jsx
+++ b/src/RadialGauge.jsx
@@ -11,6 +11,7 @@ class ReactRadialGauge extends React.Component {
   }
 
   componentWillReceiveProps (nextProps) {
+    this.gauge.value = nextProps.value
     this.gauge.update(nextProps)
   }
 


### PR DESCRIPTION
The new gauge value must be set manually prior to passing the new property object to update()

From: https://github.com/Mikhus/canvas-gauges/issues/104#issuecomment-272685636

Fixes #1